### PR TITLE
Feature | Improve array constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A strongly typed message wrapper is provided for every message in the MIDI 2.0 s
 use midi2::prelude::*;
 
 // Messages have a simple setter / getter interface
-let mut note_on = channel_voice2::NoteOn::new_arr();
+let mut note_on = channel_voice2::NoteOn::<[u32; 4]>::new();
 note_on.set_group(u4::new(0x8));
 note_on.set_channel(u4::new(0xA));
 note_on.set_note(u7::new(0x5E));
@@ -242,7 +242,7 @@ To do this simply use a backing buffer over `u8` instead of `u32`! ✨🎩
 ```rust
 use midi2::prelude::*;
 
-let mut message = channel_voice1::ChannelPressure::new_arr_bytes();
+let mut message = channel_voice1::ChannelPressure::<[u8; 3]>::new();
 message.set_channel(u4::new(0x6));
 message.set_pressure(u7::new(0x09));
 
@@ -257,7 +257,7 @@ use midi2::{
     channel_voice1::ChannelPressure,
 };
 
-let message = ChannelPressure::new_arr_bytes();
+let message = ChannelPressure::<[u8; 3]>::new();
 let message: ChannelPressure<[u32; 4]> = message.try_into_ump().
     expect("Buffer is large enough");
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ represent messages within a fixed size array.
 ```rust
 use midi2::prelude::*;
 
-let mut message = sysex8::Sysex8::<[u32; 16]>::try_new()
-    .expect("Buffer is large enough for min message size");
+let mut message = sysex8::Sysex8::<[u32; 16]>::new();
 
 // in this mode methods which would require a 
 // buffer resize are fallible

--- a/README.md
+++ b/README.md
@@ -257,8 +257,7 @@ use midi2::{
 };
 
 let message = ChannelPressure::<[u8; 3]>::new();
-let message: ChannelPressure<[u32; 4]> = message.try_into_ump().
-    expect("Buffer is large enough");
+let message: ChannelPressure<[u32; 4]> = message.into_ump();
 
 assert_eq!(message.data(), &[0x20D0_0000]);
 ```

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ let mut owned: NoteOn::<[u32; 4]> = {
     let buffer = [0x4898_5E03_u32, 0x6A14_E98A];
     // the borrowed message is immutable and cannot outlive `buffer`
     let borrowed = NoteOn::try_from(&buffer[..]).expect("Data is valid");
-    borrowed.try_rebuffer_into().expect("Buffer is large enough")
+    borrowed.rebuffer_into()
 };
 
 // the owned message is mutable and liberated from the buffer lifetime.

--- a/midi2_proc/src/generate_message.rs
+++ b/midi2_proc/src/generate_message.rs
@@ -469,6 +469,7 @@ fn new_impl(
                     + crate::buffer::BufferResize
         > #root_ident<B>
         {
+            /// Create a new message backed by a resizable buffer.
             pub fn new() -> #root_ident<B>
             {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
@@ -499,6 +500,10 @@ fn new_array_impl(
     quote! {
         impl<const SIZE: usize #generics> #root_ident<#buffer_type>
         {
+            /// Create a new message backed by a simple array type buffer.
+            ///
+            /// Note: this constructor will fail to compile for `SIZE` values
+            /// which are smaller than the minimum representable message size.
             pub fn new() -> #root_ident<#buffer_type>
             {
                 let _valid = <Self as crate::traits::ArraySizeValid<SIZE, #buffer_type>>::VALID;
@@ -524,6 +529,7 @@ fn try_new_impl(
                     + crate::buffer::BufferTryResize
         > #root_ident<B>
         {
+            /// Create a new message backed by a buffer with fallible resize.
             pub fn try_new() -> core::result::Result<#root_ident<B>, crate::error::BufferOverflow>
             {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();

--- a/midi2_proc/src/generate_message.rs
+++ b/midi2_proc/src/generate_message.rs
@@ -374,7 +374,7 @@ fn size_impl(root_ident: &syn::Ident, args: &GenerateMessageArgs) -> TokenStream
     quote! {
         impl<B: #constraint> crate::traits::Size<B> for #root_ident<B> {
             fn size(&self) -> usize {
-                <Self as crate::traits::MinSize<B>>::min_size()
+                <Self as crate::traits::MinSize<B>>::MIN_SIZE
             }
         }
     }
@@ -396,9 +396,7 @@ fn min_size_impl(root_ident: &syn::Ident, args: &GenerateMessageArgs) -> TokenSt
     let constraint = generic_buffer_constraint(args);
     quote! {
         impl<B: #constraint> crate::traits::MinSize<B> for #root_ident<B> {
-            fn min_size() -> usize {
-                #body
-            }
+            const MIN_SIZE: usize = #body;
         }
     }
 }
@@ -459,7 +457,7 @@ fn try_from_slice_impl(
         impl<'a, #generic_unit> core::convert::TryFrom<&'a [#unit_type]> for #root_ident<&'a [#unit_type]> {
             type Error = crate::error::Error;
             fn try_from(buffer: &'a [#unit_type]) -> core::result::Result<Self, Self::Error> {
-                if buffer.len() < <Self as crate::traits::MinSize<&[#unit_type]>>::min_size() {
+                if buffer.len() < <Self as crate::traits::MinSize<&[#unit_type]>>::MIN_SIZE {
                     return Err(crate::error::Error::InvalidData("Slice is too short"));
                 }
                 #validation_steps
@@ -518,7 +516,7 @@ fn new_impl(
             pub fn new() -> #root_ident<B>
             {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.resize(<Self as crate::traits::MinSize<B>>::min_size());
+                buffer.resize(<Self as crate::traits::MinSize<B>>::MIN_SIZE);
                 #initialise_properties
                 #root_ident::<B>(buffer)
             }
@@ -543,7 +541,7 @@ fn try_new_impl(
             pub fn try_new() -> core::result::Result<#root_ident<B>, crate::error::BufferOverflow>
             {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.try_resize(<Self as crate::traits::MinSize<B>>::min_size())?;
+                buffer.try_resize(<Self as crate::traits::MinSize<B>>::MIN_SIZE)?;
                 #initialise_properties
                 Ok(#root_ident::<B>(buffer))
             }
@@ -622,7 +620,7 @@ fn from_bytes_impl(root_ident: &syn::Ident, properties: &Vec<Property>) -> Token
         {
             fn from_bytes(other: #root_ident<A>) -> Self {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.resize(<#root_ident<B> as crate::traits::MinSize<B>>::min_size());
+                buffer.resize(<#root_ident<B> as crate::traits::MinSize<B>>::MIN_SIZE);
                 #convert_properties
                 Self(buffer)
             }
@@ -643,7 +641,7 @@ fn try_from_bytes_impl(root_ident: &syn::Ident, properties: &Vec<Property>) -> T
         {
             fn try_from_bytes(other: #root_ident<A>) -> core::result::Result<Self, crate::error::BufferOverflow> {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.try_resize(<#root_ident<B> as crate::traits::MinSize<B>>::min_size())?;
+                buffer.try_resize(<#root_ident<B> as crate::traits::MinSize<B>>::MIN_SIZE)?;
                 #convert_properties
                 Ok(Self(buffer))
             }
@@ -681,7 +679,7 @@ fn from_ump_impl(root_ident: &syn::Ident, properties: &Vec<Property>) -> TokenSt
         {
             fn from_ump(other: #root_ident<A>) -> Self {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.resize(<#root_ident<B> as crate::traits::MinSize<B>>::min_size());
+                buffer.resize(<#root_ident<B> as crate::traits::MinSize<B>>::MIN_SIZE);
                 #convert_properties
                 Self(buffer)
             }
@@ -702,7 +700,7 @@ fn try_from_ump_impl(root_ident: &syn::Ident, properties: &Vec<Property>) -> Tok
         {
             fn try_from_ump(other: #root_ident<A>) -> core::result::Result<Self, crate::error::BufferOverflow> {
                 let mut buffer = <B as crate::buffer::BufferDefault>::default();
-                buffer.try_resize(<#root_ident<B> as crate::traits::MinSize<B>>::min_size())?;
+                buffer.try_resize(<#root_ident<B> as crate::traits::MinSize<B>>::MIN_SIZE)?;
                 #convert_properties
                 Ok(Self(buffer))
             }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -39,8 +39,7 @@
 //! ```rust
 //! use midi2::prelude::*;
 //!
-//! let mut message = sysex8::Sysex8::<[u32; 64]>::try_new()
-//!     .expect("Buffer is large enough for default size");
+//! let mut message = sysex8::Sysex8::<[u32; 64]>::new();
 //! assert_eq!(message.try_set_payload(0..20), Ok(()));
 //! ```
 //! `Vec<U>` implements [BufferMut] and [BufferResize].

--- a/src/channel_voice1/channel_pressure.rs
+++ b/src/channel_voice1/channel_pressure.rs
@@ -194,12 +194,32 @@ mod tests {
     }
 
     #[test]
+    fn from_bytes_array() {
+        let buffer = [0xD6_u8, 0x09_u8];
+        let borrowed = ChannelPressure::try_from(&buffer[..]).unwrap();
+        assert_eq!(
+            ChannelPressure::<[u32; 1]>::from_bytes(borrowed),
+            ChannelPressure([0x20D6_0900_u32]),
+        );
+    }
+
+    #[test]
     fn try_from_ump() {
         let buffer = [0x2FD6_0900_u32];
         let borrowed = ChannelPressure::try_from(&buffer[..]).unwrap();
         assert_eq!(
             ChannelPressure::<[u8; 2]>::try_from_ump(borrowed),
             Ok(ChannelPressure([0xD6_u8, 0x09_u8])),
+        );
+    }
+
+    #[test]
+    fn from_ump_array() {
+        let buffer = [0x2FD6_0900_u32];
+        let borrowed = ChannelPressure::try_from(&buffer[..]).unwrap();
+        assert_eq!(
+            ChannelPressure::<[u8; 2]>::from_ump(borrowed),
+            ChannelPressure([0xD6_u8, 0x09_u8]),
         );
     }
 

--- a/src/channel_voice1/channel_pressure.rs
+++ b/src/channel_voice1/channel_pressure.rs
@@ -289,6 +289,16 @@ mod rebuffer_tests {
     }
 
     #[test]
+    fn rebuffer_from_array() {
+        let buffer = [0x2FD6_0900_u32];
+        let borrowed = ChannelPressure::try_from(&buffer[..]).unwrap();
+        assert_eq!(
+            ChannelPressure::<[u32; 1]>::rebuffer_from(borrowed),
+            ChannelPressure([0x2FD6_0900_u32]),
+        );
+    }
+
+    #[test]
     fn try_rebuffer_from_fail() {
         let buffer = [0x2FD6_0900_u32];
         let borrowed = ChannelPressure::try_from(&buffer[..]).unwrap();

--- a/src/channel_voice1/channel_pressure.rs
+++ b/src/channel_voice1/channel_pressure.rs
@@ -40,6 +40,22 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
+    fn new_arr() {
+        assert_eq!(
+            ChannelPressure::<[u32; 1]>::new(),
+            ChannelPressure([0x20D0_0000])
+        );
+    }
+
+    #[test]
+    fn new_arr_bytes() {
+        assert_eq!(
+            ChannelPressure::<[u8; 2]>::new(),
+            ChannelPressure([0xD0, 0x00])
+        );
+    }
+
+    #[test]
     fn setters() {
         let mut message = ChannelPressure::<[u32; 4]>::new();
         message.set_group(u4::new(0xF));

--- a/src/channel_voice1/channel_pressure.rs
+++ b/src/channel_voice1/channel_pressure.rs
@@ -160,10 +160,7 @@ mod tests {
 
     #[test]
     fn data_with_outsized_buffer() {
-        assert_eq!(
-            ChannelPressure::<[u32; 2]>::try_new().unwrap().data(),
-            &[0x20D0_0000]
-        );
+        assert_eq!(ChannelPressure::<[u32; 2]>::new().data(), &[0x20D0_0000]);
     }
 
     #[test]
@@ -223,18 +220,18 @@ mod tests {
     }
 
     #[test]
-    fn try_new_with_custom_buffer() {
+    fn new_with_arr() {
         assert_eq!(
-            ChannelPressure::<[u32; 2]>::try_new(),
-            Ok(ChannelPressure([0x20D0_0000, 0x0]))
+            ChannelPressure::<[u32; 2]>::new(),
+            ChannelPressure([0x20D0_0000, 0x0]),
         )
     }
 
     #[test]
-    fn try_new_with_custom_buffer_bytes() {
+    fn new_with_arr_bytes() {
         assert_eq!(
-            ChannelPressure::<[u8; 3]>::try_new(),
-            Ok(ChannelPressure([0xD0, 0x00, 0x0]))
+            ChannelPressure::<[u8; 3]>::new(),
+            ChannelPressure([0xD0, 0x00, 0x0]),
         )
     }
 

--- a/src/channel_voice1/channel_pressure.rs
+++ b/src/channel_voice1/channel_pressure.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = ChannelPressure::new_arr();
+        let mut message = ChannelPressure::<[u32; 4]>::new();
         message.set_group(u4::new(0xF));
         message.set_channel(u4::new(0x6));
         message.set_pressure(u7::new(0x09));
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn setters_bytes() {
-        let mut message = ChannelPressure::new_arr_bytes();
+        let mut message = ChannelPressure::<[u8; 3]>::new();
         message.set_channel(u4::new(0x6));
         message.set_pressure(u7::new(0x09));
         assert_eq!(message, ChannelPressure([0xD6, 0x09, 0x0]));
@@ -194,7 +194,7 @@ mod tests {
     fn new_with_custom_buffer() {
         assert_eq!(
             ChannelPressure::<std::vec::Vec<u32>>::new(),
-            ChannelPressure::new_arr().rebuffer_into(),
+            ChannelPressure::<[u32; 4]>::new().rebuffer_into(),
         )
     }
 
@@ -359,7 +359,7 @@ mod rebuffer_tests {
 
     #[test]
     fn clone() {
-        let message = ChannelPressure::new_arr();
+        let message = ChannelPressure::<[u32; 4]>::new();
         let clone = message.clone();
         assert_eq!(message, clone);
     }

--- a/src/channel_voice1/control_change.rs
+++ b/src/channel_voice1/control_change.rs
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = ControlChange::new_arr();
+        let mut message = ControlChange::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_channel(u4::new(0x7));
         message.set_control(u7::new(0x36));
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn setters_bytes() {
-        let mut message = ControlChange::new_arr_bytes();
+        let mut message = ControlChange::<[u8; 3]>::new();
         message.set_channel(u4::new(0x7));
         message.set_control(u7::new(0x36));
         message.set_control_data(u7::new(0x37));

--- a/src/channel_voice1/key_pressure.rs
+++ b/src/channel_voice1/key_pressure.rs
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = KeyPressure::new_arr();
+        let mut message = KeyPressure::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_channel(u4::new(0x3));
         message.set_note(u7::new(0x7F));

--- a/src/channel_voice1/note_off.rs
+++ b/src/channel_voice1/note_off.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = NoteOff::new_arr();
+        let mut message = NoteOff::<[u32; 4]>::new();
         message.set_group(u4::new(0x1));
         message.set_channel(u4::new(0xA));
         message.set_note(u7::new(0x68));

--- a/src/channel_voice1/note_on.rs
+++ b/src/channel_voice1/note_on.rs
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = NoteOn::new_arr();
+        let mut message = NoteOn::<[u32; 4]>::new();
         message.set_group(u4::new(0xD));
         message.set_channel(u4::new(0xE));
         message.set_note(u7::new(0x75));

--- a/src/channel_voice1/pitch_bend.rs
+++ b/src/channel_voice1/pitch_bend.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = PitchBend::new_arr();
+        let mut message = PitchBend::<[u32; 4]>::new();
         message.set_group(u4::new(0x1));
         message.set_channel(u4::new(0xE));
         message.set_bend(u14::new(0x147));

--- a/src/channel_voice1/program_change.rs
+++ b/src/channel_voice1/program_change.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = ProgramChange::new_arr();
+        let mut message = ProgramChange::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_channel(u4::new(0x7));
         message.set_program(u7::new(0x63));

--- a/src/channel_voice2/assignable_controller.rs
+++ b/src/channel_voice2/assignable_controller.rs
@@ -33,7 +33,7 @@ mod tests {
     fn setters() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = AssignableController::new_arr();
+        let mut message = AssignableController::<[u32; 4]>::new();
         message.set_group(u4::new(0xC));
         message.set_channel(u4::new(0x8));
         message.set_bank(u7::new(0x51));

--- a/src/channel_voice2/assignable_per_note_controller.rs
+++ b/src/channel_voice2/assignable_per_note_controller.rs
@@ -33,7 +33,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = AssignablePerNoteController::new_arr();
+        let mut message = AssignablePerNoteController::<[u32; 4]>::new();
         message.set_group(u4::new(0x2));
         message.set_channel(u4::new(0x4));
         message.set_note(u7::new(0x6F));

--- a/src/channel_voice2/channel_pitch_bend.rs
+++ b/src/channel_voice2/channel_pitch_bend.rs
@@ -29,7 +29,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = ChannelPitchBend::new_arr();
+        let mut message = ChannelPitchBend::<[u32; 4]>::new();
         message.set_group(u4::new(0xB));
         message.set_channel(u4::new(0x9));
         message.set_pitch_bend_data(0x08306AF8);

--- a/src/channel_voice2/channel_pressure.rs
+++ b/src/channel_voice2/channel_pressure.rs
@@ -33,7 +33,7 @@ mod tests {
     fn setter() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = ChannelPressure::new_arr();
+        let mut message = ChannelPressure::<[u32; 4]>::new();
         message.set_group(u4::new(0xE));
         message.set_channel(u4::new(0xD));
         message.set_channel_pressure_data(0xDE0DE0F2);
@@ -41,6 +41,22 @@ mod tests {
         assert_eq!(
             message,
             ChannelPressure([0x4EDD_0000, 0xDE0D_E0F2, 0x0, 0x0]),
+        );
+    }
+
+    #[test]
+    fn new_arr_3() {
+        assert_eq!(
+            ChannelPressure::<[u32; 3]>::new(),
+            ChannelPressure([0x40D0_0000, 0x0, 0x0]),
+        );
+    }
+
+    #[test]
+    fn new_arr_2() {
+        assert_eq!(
+            ChannelPressure::<[u32; 2]>::new(),
+            ChannelPressure([0x40D0_0000, 0x0]),
         );
     }
 

--- a/src/channel_voice2/control_change.rs
+++ b/src/channel_voice2/control_change.rs
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn setters() {
         use crate::traits::{Channeled, Grouped};
-        let mut message = ControlChange::new_arr();
+        let mut message = ControlChange::<[u32; 4]>::new();
         message.set_group(u4::new(0x3));
         message.set_channel(u4::new(0x9));
         message.set_control(u7::new(0x30));

--- a/src/channel_voice2/key_pressure.rs
+++ b/src/channel_voice2/key_pressure.rs
@@ -31,7 +31,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = KeyPressure::new_arr();
+        let mut message = KeyPressure::<[u32; 4]>::new();
         message.set_group(u4::new(0xB));
         message.set_channel(u4::new(0xC));
         message.set_note(u7::new(0x59));

--- a/src/channel_voice2/note_off.rs
+++ b/src/channel_voice2/note_off.rs
@@ -36,7 +36,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = NoteOff::new_arr();
+        let mut message = NoteOff::<[u32; 4]>::new();
         message.set_group(u4::new(0x2));
         message.set_channel(u4::new(0x4));
         message.set_note(u7::new(0x4E));
@@ -50,7 +50,7 @@ mod tests {
     fn builder_no_attribute() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = NoteOff::new_arr();
+        let mut message = NoteOff::<[u32; 4]>::new();
         message.set_group(u4::new(0x2));
         message.set_channel(u4::new(0x4));
         message.set_note(u7::new(0x4E));

--- a/src/channel_voice2/note_on.rs
+++ b/src/channel_voice2/note_on.rs
@@ -17,7 +17,7 @@ pub(crate) const STATUS: u8 = 0b1001;
 /// use midi2::prelude::*;
 /// use midi2::prelude::*;
 ///
-/// let mut message = channel_voice2::NoteOn::new_arr();
+/// let mut message = channel_voice2::NoteOn::<[u32; 4]>::new();
 /// message.set_group(u4::new(0x8));
 /// message.set_channel(u4::new(0x8));
 /// message.set_note(u7::new(0x5E));
@@ -57,7 +57,7 @@ mod tests {
         use crate::traits::{Channeled, Grouped};
         use crate::ux::u9;
 
-        let mut message = NoteOn::new_arr();
+        let mut message = NoteOn::<[u32; 4]>::new();
         message.set_group(u4::new(0x8));
         message.set_channel(u4::new(0x8));
         message.set_note(u7::new(0x5E));
@@ -74,7 +74,7 @@ mod tests {
     fn builder_no_attribute() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = NoteOn::new_arr();
+        let mut message = NoteOn::<[u32; 4]>::new();
         message.set_group(u4::new(0x8));
         message.set_channel(u4::new(0x8));
         message.set_note(u7::new(0x5E));

--- a/src/channel_voice2/per_note_management.rs
+++ b/src/channel_voice2/per_note_management.rs
@@ -33,7 +33,7 @@ mod tests {
     fn setters() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = PerNoteManagement::new_arr();
+        let mut message = PerNoteManagement::<[u32; 4]>::new();
         message.set_group(u4::new(0xB));
         message.set_channel(u4::new(0x9));
         message.set_note(u7::new(0x1C));

--- a/src/channel_voice2/per_note_pitch_bend.rs
+++ b/src/channel_voice2/per_note_pitch_bend.rs
@@ -31,7 +31,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = PerNotePitchBend::new_arr();
+        let mut message = PerNotePitchBend::<[u32; 4]>::new();
         message.set_group(u4::new(0x9));
         message.set_channel(u4::new(0x2));
         message.set_note(u7::new(0x76));

--- a/src/channel_voice2/program_change.rs
+++ b/src/channel_voice2/program_change.rs
@@ -80,7 +80,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = ProgramChange::new_arr();
+        let mut message = ProgramChange::<[u32; 4]>::new();
         message.set_group(u4::new(0xF));
         message.set_channel(u4::new(0xE));
         message.set_program(u7::new(0x75));
@@ -93,7 +93,7 @@ mod tests {
     fn builder_no_bank() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = ProgramChange::new_arr();
+        let mut message = ProgramChange::<[u32; 4]>::new();
         message.set_group(u4::new(0xF));
         message.set_channel(u4::new(0xE));
         message.set_program(u7::new(0x75));

--- a/src/channel_voice2/registered_controller.rs
+++ b/src/channel_voice2/registered_controller.rs
@@ -33,7 +33,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = RegisteredController::new_arr();
+        let mut message = RegisteredController::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_channel(u4::new(0xB));
         message.set_bank(u7::new(0x7D));

--- a/src/channel_voice2/registered_per_note_controller.rs
+++ b/src/channel_voice2/registered_per_note_controller.rs
@@ -31,7 +31,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = RegisteredPerNoteController::new_arr();
+        let mut message = RegisteredPerNoteController::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_channel(u4::new(0x5));
         message.set_note(u7::new(0x6C));

--- a/src/channel_voice2/relative_assignable_controller.rs
+++ b/src/channel_voice2/relative_assignable_controller.rs
@@ -33,7 +33,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = RelativeAssignableController::new_arr();
+        let mut message = RelativeAssignableController::<[u32; 4]>::new();
         message.set_group(u4::new(0x3));
         message.set_channel(u4::new(0x1));
         message.set_bank(u7::new(0x24));

--- a/src/channel_voice2/relative_registered_controller.rs
+++ b/src/channel_voice2/relative_registered_controller.rs
@@ -33,7 +33,7 @@ mod tests {
     fn builder() {
         use crate::traits::{Channeled, Grouped};
 
-        let mut message = RelativeRegisteredController::new_arr();
+        let mut message = RelativeRegisteredController::<[u32; 4]>::new();
         message.set_group(u4::new(0x1));
         message.set_channel(u4::new(0xE));
         message.set_bank(u7::new(0x45));

--- a/src/flex_data/set_chord_name.rs
+++ b/src/flex_data/set_chord_name.rs
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = SetChordName::new_arr();
+        let mut message = SetChordName::<[u32; 4]>::new();
         message.set_group(u4::new(0x7));
         message.set_optional_channel(Some(u4::new(0xB)));
         message.set_tonic_sharps_flats(SharpsFlats::Flat);

--- a/src/flex_data/set_key_signature.rs
+++ b/src/flex_data/set_key_signature.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = SetKeySignature::new_arr();
+        let mut message = SetKeySignature::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_tonic(flex_data::tonic::Tonic::D);
         message.set_sharps_flats(SharpsFlats::Sharps(u3::new(5)));
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn set_flats() {
-        let mut message = SetKeySignature::new_arr();
+        let mut message = SetKeySignature::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_tonic(flex_data::tonic::Tonic::D);
         message.set_sharps_flats(SharpsFlats::Flats(u3::new(5)));
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn builder_non_standard() {
-        let mut message = SetKeySignature::new_arr();
+        let mut message = SetKeySignature::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_tonic(flex_data::tonic::Tonic::NonStandard);
         message.set_sharps_flats(SharpsFlats::NonStandard);
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn builder_channel() {
-        let mut message = SetKeySignature::new_arr();
+        let mut message = SetKeySignature::<[u32; 4]>::new();
         message.set_group(u4::new(0x4));
         message.set_tonic(flex_data::tonic::Tonic::NonStandard);
         message.set_sharps_flats(SharpsFlats::NonStandard);

--- a/src/flex_data/set_metronome.rs
+++ b/src/flex_data/set_metronome.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = SetMetronome::new_arr();
+        let mut message = SetMetronome::<[u32; 4]>::new();
         message.set_group(u4::new(0x1));
         message.set_number_of_clocks_per_primary_click(0x9B);
         message.set_bar_accent1(0x4A);

--- a/src/flex_data/set_tempo.rs
+++ b/src/flex_data/set_tempo.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = SetTempo::new_arr();
+        let mut message = SetTempo::<[u32; 4]>::new();
         message.set_group(u4::new(0x7));
         message.set_number_of_10_nanosecond_units_per_quarter_note(0xF751FE05);
         assert_eq!(message, SetTempo([0xD710_0000, 0xF751_FE05, 0x0, 0x0,]),);

--- a/src/flex_data/set_time_signature.rs
+++ b/src/flex_data/set_time_signature.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = SetTimeSignature::new_arr();
+        let mut message = SetTimeSignature::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_numerator(0xCD);
         message.set_denominator(0x90);

--- a/src/flex_data/unknown_metadata_text.rs
+++ b/src/flex_data/unknown_metadata_text.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn try_set_text() {
-        let mut message = UnknownMetadataText::<[u32; 8]>::try_new().unwrap();
+        let mut message = UnknownMetadataText::<[u32; 8]>::new();
         message
             .try_set_text("Gimme some signal!")
             .expect("Shouldn't fail");

--- a/src/flex_data/unknown_metadata_text.rs
+++ b/src/flex_data/unknown_metadata_text.rs
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn set_string_multiple_of_12_length() {
-        let mut message = UnknownMetadataText::new();
+        let mut message = UnknownMetadataText::<std::vec::Vec<u32>>::new();
         message.set_text("Digital Audio Workstation - DAW36-16");
         assert_eq!(
             message,

--- a/src/message.rs
+++ b/src/message.rs
@@ -273,7 +273,7 @@ mod tests {
     fn from_level2() {
         use crate::channel_voice1::ChannelPressure;
 
-        let level2_message = ChannelPressure::new_arr();
+        let level2_message = ChannelPressure::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 
@@ -291,7 +291,7 @@ mod tests {
     fn from_level2_bytes() {
         use crate::channel_voice1::ChannelPressure;
 
-        let level2_message = ChannelPressure::new_arr_bytes();
+        let level2_message = ChannelPressure::<[u8; 3]>::new();
         let _: BytesMessage<[u8; 3]> = level2_message.into();
     }
 
@@ -300,7 +300,7 @@ mod tests {
     fn from_level2_channel_voice2() {
         use crate::channel_voice2::ChannelPressure;
 
-        let level2_message = ChannelPressure::new_arr();
+        let level2_message = ChannelPressure::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 
@@ -309,7 +309,7 @@ mod tests {
     fn from_level2_ump_stream() {
         use crate::ump_stream::EndOfClip;
 
-        let level2_message = EndOfClip::new_arr();
+        let level2_message = EndOfClip::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 
@@ -318,7 +318,7 @@ mod tests {
     fn from_level2_utility() {
         use crate::utility::DeltaClockstampTPQ;
 
-        let level2_message = DeltaClockstampTPQ::new_arr();
+        let level2_message = DeltaClockstampTPQ::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 
@@ -327,7 +327,7 @@ mod tests {
     fn from_level2_system_common() {
         use crate::system_common::Stop;
 
-        let level2_message = Stop::new_arr();
+        let level2_message = Stop::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -282,7 +282,7 @@ mod tests {
     fn from_level2_flex_data() {
         use crate::flex_data::Lyrics;
 
-        let level2_message = Lyrics::<[u32; 4]>::try_new().expect("Buffer large enough");
+        let level2_message = Lyrics::<[u32; 4]>::new();
         let _: UmpMessage<[u32; 4]> = level2_message.into();
     }
 

--- a/src/sysex7/README.md
+++ b/src/sysex7/README.md
@@ -109,8 +109,7 @@ Use with fixed size, or fallible buffers.
 ```rust
 use midi2::prelude::*;
 
-let mut message = sysex7::Sysex7::<[u8; 22]>::try_new()
-    .expect("Buffer is large enough");
+let mut message = sysex7::Sysex7::<[u8; 22]>::new();
 
 // only fallible methods are available
 assert_eq!(message.try_set_payload((0u8..20u8).map(u7::new)), Ok(()));

--- a/src/sysex7/mod.rs
+++ b/src/sysex7/mod.rs
@@ -1152,7 +1152,7 @@ mod tests {
 
     #[test]
     fn try_set_payload_bytes() {
-        let mut message = Sysex7::<[u8; 22]>::try_new().unwrap();
+        let mut message = Sysex7::<[u8; 22]>::new();
         message.try_set_payload((0u8..20u8).map(u7::new)).unwrap();
         assert_eq!(
             message,
@@ -1165,7 +1165,7 @@ mod tests {
 
     #[test]
     fn try_set_payload_bytes_fail() {
-        let mut message = Sysex7::<[u8; 22]>::try_new().unwrap();
+        let mut message = Sysex7::<[u8; 22]>::new();
         assert_eq!(
             message.try_set_payload((0u8..30u8).map(u7::new)),
             Err(crate::error::BufferOverflow),
@@ -1226,7 +1226,7 @@ mod tests {
     #[test]
     fn try_set_rubbish_payload_to_fixed_size_buffer_ump() {
         use crate::detail::test_support::rubbish_payload_iterator::RubbishPayloadIterator;
-        let mut message = Sysex7::<[u32; 18]>::try_new().unwrap();
+        let mut message = Sysex7::<[u32; 18]>::new();
         message
             .try_set_payload(RubbishPayloadIterator::new().map(u7::new))
             .expect("Shouldn't fail");
@@ -1302,7 +1302,7 @@ mod tests {
     #[test]
     fn try_set_rubbish_payload_to_fixed_size_buffer() {
         use crate::detail::test_support::rubbish_payload_iterator::RubbishPayloadIterator;
-        let mut message = Sysex7::<[u8; 52]>::try_new().unwrap();
+        let mut message = Sysex7::<[u8; 52]>::new();
         message
             .try_set_payload(RubbishPayloadIterator::new().map(u7::new))
             .expect("Shouldn't fail");
@@ -1524,7 +1524,7 @@ mod tests {
 
     #[test]
     fn set_payload_to_fixed_size_buffer_with_overflow() {
-        let mut message = Sysex7::<[u32; 8]>::try_new().unwrap();
+        let mut message = Sysex7::<[u32; 8]>::new();
         assert_eq!(
             message.try_set_payload((0..30).map(u7::new)),
             Err(crate::error::BufferOverflow)

--- a/src/sysex7/mod.rs
+++ b/src/sysex7/mod.rs
@@ -388,7 +388,7 @@ fn try_from_other<
     let mut buffer = <B as crate::buffer::BufferDefault>::default();
     try_resize(
         &mut buffer,
-        <Sysex7<B> as crate::traits::MinSize<B>>::min_size(),
+        <Sysex7<B> as crate::traits::MinSize<B>>::MIN_SIZE,
     )?;
 
     convert_generated_properties(&other.0, &mut buffer);

--- a/src/sysex8/mod.rs
+++ b/src/sysex8/mod.rs
@@ -918,7 +918,7 @@ mod tests {
     #[test]
     fn set_rubbish_payload_to_fixed_size_buffer() {
         use crate::detail::test_support::rubbish_payload_iterator::RubbishPayloadIterator;
-        let mut message = Sysex8::<[u32; 16]>::try_new().unwrap();
+        let mut message = Sysex8::<[u32; 16]>::new();
         assert_eq!(
             message.try_set_payload(RubbishPayloadIterator::new()),
             Ok(())
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn set_and_reset_payload_fixed_size_buffer() {
-        let mut message = Sysex8::<[u32; 13]>::try_new().unwrap();
+        let mut message = Sysex8::<[u32; 13]>::new();
         assert_eq!(message.try_set_payload(0..30), Ok(()));
         assert_eq!(message.try_set_payload(0..20), Ok(()));
         assert_eq!(
@@ -988,7 +988,7 @@ mod tests {
 
     #[test]
     fn set_payload_to_fixed_size_buffer_with_overflow() {
-        let mut message = Sysex8::<[u32; 16]>::try_new().unwrap();
+        let mut message = Sysex8::<[u32; 16]>::new();
         assert_eq!(
             message.try_set_payload(0..60),
             Err(crate::error::BufferOverflow)

--- a/src/system_common/README.md
+++ b/src/system_common/README.md
@@ -15,7 +15,7 @@ standards.
 ```rust
 use midi2::prelude::*;
 
-let mut message = system_common::SongSelect::new_arr_bytes();
+let mut message = system_common::SongSelect::<[u8; 3]>::new();
 message.set_song(u7::new(0x42));
 assert_eq!(message.data(), &[0xF3, 0x42]);
 ```
@@ -26,7 +26,7 @@ encoded into Universal Message Packets.
 ```rust
 use midi2::prelude::*;
 
-let mut message = system_common::SongSelect::new_arr();
+let mut message = system_common::SongSelect::<[u32; 4]>::new();
 message.set_song(u7::new(0x42));
 message.set_group(u4::new(0x3));
 assert_eq!(message.data(), &[0x13F3_4200]);

--- a/src/system_common/song_position_pointer.rs
+++ b/src/system_common/song_position_pointer.rs
@@ -34,14 +34,14 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = SongPositionPointer::new_arr();
+        let mut message = SongPositionPointer::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_position(u14::new(0x367D));
         assert_eq!(message, SongPositionPointer([0x1AF2_7D6C, 0x0, 0x0, 0x0]),);
     }
     #[test]
     fn setters_bytes() {
-        let mut message = SongPositionPointer::new_arr_bytes();
+        let mut message = SongPositionPointer::<[u8; 3]>::new();
         message.set_position(u14::new(0x367D));
         assert_eq!(message, SongPositionPointer([0xF2, 0x7D, 0x6C]),);
     }

--- a/src/system_common/song_select.rs
+++ b/src/system_common/song_select.rs
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn setter() {
-        let mut message = SongSelect::new_arr();
+        let mut message = SongSelect::<[u32; 4]>::new();
         message.set_group(u4::new(0xA));
         message.set_song(u7::new(0x4F));
         assert_eq!(message, SongSelect([0x1AF3_4F00, 0x0, 0x0, 0x0]),);
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn setters_bytes() {
-        let mut message = SongSelect::new_arr_bytes();
+        let mut message = SongSelect::<[u8; 3]>::new();
         message.set_song(u7::new(0x4F));
         assert_eq!(message, SongSelect([0xF3, 0x4F, 0x0]),);
     }

--- a/src/system_common/time_code.rs
+++ b/src/system_common/time_code.rs
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn setter() {
-        let mut message = TimeCode::new_arr();
+        let mut message = TimeCode::<[u32; 4]>::new();
         message.set_group(u4::new(0x5));
         message.set_time_code(u7::new(0x5F));
         assert_eq!(message, TimeCode([0x15F1_5F00, 0x0, 0x0, 0x0]),);
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn setters_bytes() {
-        let mut message = TimeCode::new_arr_bytes();
+        let mut message = TimeCode::<[u8; 3]>::new();
         message.set_time_code(u7::new(0x5F));
         assert_eq!(message, TimeCode([0xF1, 0x5F, 0x0,]),);
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -173,6 +173,16 @@ pub(crate) trait MinSize<B: Buffer> {
     const MIN_SIZE: usize;
 }
 
+pub(crate) trait ArraySizeValid<const SIZE: usize, B: Buffer>: MinSize<B> {
+    const VALID: ();
+}
+
+impl<const SIZE: usize, B: Buffer, M: MinSize<B>> ArraySizeValid<SIZE, B> for M {
+    const VALID: () = if SIZE < <Self as MinSize<B>>::MIN_SIZE {
+        panic!("Array is shorter than minimum message size");
+    };
+}
+
 pub(crate) trait Size<B: Buffer> {
     fn size(&self) -> usize;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -170,7 +170,7 @@ pub(crate) trait SysexInternal<B: crate::buffer::Buffer>: Sysex<B> {
 }
 
 pub(crate) trait MinSize<B: Buffer> {
-    fn min_size() -> usize;
+    const MIN_SIZE: usize;
 }
 
 pub(crate) trait Size<B: Buffer> {

--- a/src/ump_stream/device_identity.rs
+++ b/src/ump_stream/device_identity.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = DeviceIdentity::new_arr();
+        let mut message = DeviceIdentity::<[u32; 4]>::new();
         message.set_device_manufacturer([u7::new(0x0F), u7::new(0x33), u7::new(0x28)]);
         message.set_device_family(u14::new(0xF4A));
         message.set_device_family_model_number(u14::new(0x3818));

--- a/src/ump_stream/end_of_clip.rs
+++ b/src/ump_stream/end_of_clip.rs
@@ -20,7 +20,7 @@ mod tests {
     #[test]
     fn setters() {
         assert_eq!(
-            EndOfClip::new_arr(),
+            EndOfClip::<[u32; 4]>::new(),
             EndOfClip([0xF021_0000, 0x0, 0x0, 0x0])
         );
     }

--- a/src/ump_stream/endpoint_discovery.rs
+++ b/src/ump_stream/endpoint_discovery.rs
@@ -37,7 +37,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = EndpointDiscovery::new_arr();
+        let mut message = EndpointDiscovery::<[u32; 4]>::new();
         message.set_ump_version_major(0x1);
         message.set_ump_version_minor(0x1);
         message.set_request_endpoint_info(true);

--- a/src/ump_stream/endpoint_info.rs
+++ b/src/ump_stream/endpoint_info.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = EndpointInfo::new_arr();
+        let mut message = EndpointInfo::<[u32; 4]>::new();
         message.set_ump_version_major(0x1);
         message.set_ump_version_minor(0x1);
         message.set_static_function_blocks(true);

--- a/src/ump_stream/endpoint_name.rs
+++ b/src/ump_stream/endpoint_name.rs
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn set_name_and_clear_name() {
-        let mut message = EndpointName::new();
+        let mut message = EndpointName::<std::vec::Vec<u32>>::new();
         message.set_name("Gimme some signal 🔊 🙌");
         message.set_name("");
         assert_eq!(

--- a/src/ump_stream/function_block_discovery.rs
+++ b/src/ump_stream/function_block_discovery.rs
@@ -30,7 +30,7 @@ mod tests {
 
     #[test]
     fn setters() {
-        let mut message = FunctionBlockDiscovery::new_arr();
+        let mut message = FunctionBlockDiscovery::<[u32; 4]>::new();
         message.set_function_block_number(0x09);
         message.set_requesting_function_block_info(true);
         message.set_requesting_function_block_name(true);

--- a/src/ump_stream/function_block_info.rs
+++ b/src/ump_stream/function_block_info.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = FunctionBlockInfo::new_arr();
+        let mut message = FunctionBlockInfo::<[u32; 4]>::new();
         message.set_active(true);
         message.set_function_block_number(u7::new(0x11));
         message.set_first_group(u4::new(0xD));

--- a/src/ump_stream/function_block_name.rs
+++ b/src/ump_stream/function_block_name.rs
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn set_name() {
-        let mut message = FunctionBlockName::new();
+        let mut message = FunctionBlockName::<std::vec::Vec<u32>>::new();
         message.set_name("SynthWave🌊²");
         message.set_function_block(0x09);
         assert_eq!(

--- a/src/ump_stream/product_instance_id.rs
+++ b/src/ump_stream/product_instance_id.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn set_id() {
-        let mut message = ProductInstanceId::new();
+        let mut message = ProductInstanceId::<std::vec::Vec<u32>>::new();
         message.set_id("PianoPulse");
         assert_eq!(
             message,

--- a/src/ump_stream/start_of_clip.rs
+++ b/src/ump_stream/start_of_clip.rs
@@ -20,7 +20,7 @@ mod tests {
     #[test]
     fn builder() {
         assert_eq!(
-            StartOfClip::new_arr(),
+            StartOfClip::<[u32; 4]>::new(),
             StartOfClip([0xF020_0000, 0x0, 0x0, 0x0]),
         );
     }

--- a/src/ump_stream/stream_configuration_notification.rs
+++ b/src/ump_stream/stream_configuration_notification.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = StreamConfigurationNotification::new_arr();
+        let mut message = StreamConfigurationNotification::<[u32; 4]>::new();
         message.set_protocol(0x2);
         message.set_receive_jr_timestamps(true);
         message.set_send_jr_timestamps(true);

--- a/src/ump_stream/stream_configuration_request.rs
+++ b/src/ump_stream/stream_configuration_request.rs
@@ -29,7 +29,7 @@ mod tests {
 
     #[test]
     fn builder() {
-        let mut message = StreamConfigurationRequest::new_arr();
+        let mut message = StreamConfigurationRequest::<[u32; 4]>::new();
         message.set_protocol(0x2);
         message.set_receive_jr_timestamps(true);
         message.set_send_jr_timestamps(true);

--- a/src/utility/mod.rs
+++ b/src/utility/mod.rs
@@ -82,13 +82,13 @@ mod timestamp {
 
         #[test]
         fn new_arr() {
-            let message = Timestamp::new_arr();
+            let message = Timestamp::<[u32; 4]>::new();
             assert_eq!(message, Timestamp([0x0020_0000, 0x0, 0x0, 0x0]));
         }
 
         #[test]
         fn rebuffer_into() {
-            let message = Timestamp::new_arr();
+            let message = Timestamp::<[u32; 4]>::new();
             let rebuffered: Timestamp<std::vec::Vec<u32>> = message.rebuffer_into();
             assert_eq!(rebuffered, Timestamp(std::vec![0x0020_0000]));
         }


### PR DESCRIPTION
## Context

In order to create a messages backed by a simple array (a pretty common use case) we had dedicated `new_arr` and `new_arr_bytes` constructors which would construct messages backed by `[u32; 4]` and `[u8; 3]` respectively. This was ok, but if I wanted to create a message backed with a `[u32; 2]` I would need to use `try_new`, even though I know at compile time that the buffer would be large enough to fit the message.

Additionally, the conversion traits `FromUmp`, `IntoUmp`, `FromBytes`, `IntoBytes`, `RebufferFrom` and `RebufferInto` would only be available in their fallible versions if the target message was an array because we didn't have compile-time checks on the minimum message size.

## The Changes

### `new`

All messages, when backed by an array type buffer have a new `new` constructor specialisation. The size of the target array is checked at compile time, so that `new` will be valid so long as the array has a size larger than the messages minimum representable size.

```rust
let sysex = Sysex7::<[u32; 2]>::new();
let big_sysex = Sysex7::<[u32; 16]>::new();
let small_sysex = Sysex7::<[u32; 1]>::new(); // won't compile
```

### ⚠️ Breaking Change ⚠️

We remove the `new_arr` and `new_arr_bytes` constructors in favour of using the more flexible and more consistent `new` constructor on the explicit array generic specialisation.

```rust
let message_128 = ChannelPressure::<[u32; 4]>::new();
let message_64 = ChannelPressure::<[u32; 2]>::new();
```

### Conversion Traits

When message is fixed size and the target message is array-backed, and the array has a size greater than the smallest representable size for the message, the conversion traits `FromUmp`, `IntoUmp`, `FromBytes`, `IntoBytes`, `RebufferFrom` and `RebufferInto` can be used in their non-fallible forms.

```rust
let message = ChannelPressure::<[u8; 3]>::new();
let message: ChannelPressure<[u32; 4]> = message.into_ump();
```