### PR TITLE
Feature | Packets trait

### DIFF
--- a/midi2_proc/src/derives.rs
+++ b/midi2_proc/src/derives.rs
@@ -31,6 +31,29 @@ pub fn data(item: TokenStream1) -> TokenStream1 {
     .into()
 }
 
+pub fn packets(item: TokenStream1) -> TokenStream1 {
+    let input = parse_macro_input!(item as ItemEnum);
+    let ident = &input.ident;
+    let mut match_arms = TokenStream::new();
+    for variant in &input.variants {
+        let variant_ident = &variant.ident;
+        match_arms.extend(quote! {
+            #variant_ident(m) => m.packets(),
+        });
+    }
+    quote! {
+        impl<B: crate::buffer::Ump>  crate::Packets for #ident<B>  {
+            fn packets(&self) -> crate::PacketsIterator {
+                use #ident::*;
+                match self {
+                    #match_arms
+                }
+            }
+        }
+    }
+    .into()
+}
+
 pub fn from_bytes(item: TokenStream1) -> TokenStream1 {
     let input = parse_macro_input!(item as ItemEnum);
     let ident = &input.ident;

--- a/midi2_proc/src/lib.rs
+++ b/midi2_proc/src/lib.rs
@@ -14,6 +14,11 @@ pub fn derive_data(item: TokenStream1) -> TokenStream1 {
     derives::data(item)
 }
 
+#[proc_macro_derive(Packets)]
+pub fn derive_packets(item: TokenStream1) -> TokenStream1 {
+    derives::packets(item)
+}
+
 #[proc_macro_derive(Grouped)]
 pub fn derive_grouped(item: TokenStream1) -> TokenStream1 {
     derives::grouped(item)

--- a/src/channel_voice1.rs
+++ b/src/channel_voice1.rs
@@ -21,6 +21,7 @@ pub(crate) const UMP_MESSAGE_TYPE: u8 = 0x2;
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::Channeled,
     midi2_proc::Grouped,
     midi2_proc::FromBytes,
@@ -82,11 +83,8 @@ fn status<U: crate::buffer::Unit>(buffer: &[U]) -> u8 {
 mod test {
     use super::*;
     use crate::{
-        traits::{
-            Channeled, Data, FromBytes, FromUmp, Grouped, RebufferInto, TryFromBytes, TryFromUmp,
-            TryRebufferInto,
-        },
-        ux::*,
+        ux::*, Channeled, Data, FromBytes, FromUmp, Grouped, Packets, RebufferInto, TryFromBytes,
+        TryFromUmp, TryRebufferInto,
     };
     use pretty_assertions::assert_eq;
 
@@ -176,5 +174,13 @@ mod test {
             .try_rebuffer_into()
             .unwrap();
         assert_eq!(message.data(), &[0x2FD6_0900]);
+    }
+
+    #[test]
+    fn packets() {
+        let message = ChannelVoice1::try_from(&[0x2FD6_0900_u32][..]).unwrap();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x2FD6_0900_u32][..]));
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/channel_voice1/control_change.rs
+++ b/src/channel_voice1/control_change.rs
@@ -37,10 +37,7 @@ struct ControlChange {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        traits::{Channeled, Grouped},
-        ux::*,
-    };
+    use crate::{ux::*, Channeled, Grouped, Packets};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -130,5 +127,14 @@ mod tests {
                 .control_data(),
             u7::new(0x37),
         );
+    }
+
+    #[test]
+    fn packets() {
+        let buffer = [0x2AB7_3637_u32];
+        let message = ControlChange::try_from(&buffer[..]).unwrap();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x2AB7_3637_u32][..]));
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/channel_voice2.rs
+++ b/src/channel_voice2.rs
@@ -39,6 +39,7 @@ pub(crate) const UMP_MESSAGE_TYPE: u8 = 0x4;
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::Channeled,
     midi2_proc::Grouped,
     midi2_proc::RebufferFrom,
@@ -136,5 +137,15 @@ mod test {
                 .channel(),
             u4::new(0xC),
         );
+    }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = ChannelVoice2::try_from(&[0x4BAC_5900, 0xC0B83064][..]).unwrap();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x4BAC_5900, 0xC0B83064][..]));
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/channel_voice2/assignable_controller.rs
+++ b/src/channel_voice2/assignable_controller.rs
@@ -98,4 +98,15 @@ mod tests {
             0x3F3ADD42,
         );
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let buffer = [0x4C38_5138, 0x3F3ADD42];
+        let message = AssignableController::try_from(&buffer[..]).unwrap();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x4C38_5138, 0x3F3ADD42][..]));
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/flex_data.rs
+++ b/src/flex_data.rs
@@ -752,6 +752,7 @@ pub(crate) const PERFORMANCE_TEXT_BANK: u8 = 0x2;
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::Grouped,
     midi2_proc::RebufferFrom,
     midi2_proc::TryRebufferFrom,
@@ -1201,5 +1202,45 @@ mod tests {
                 .bank(),
             Bank::SetupAndPerformance,
         );
+    }
+
+    #[test]
+    fn packets_small() {
+        use crate::Packets;
+
+        let message = FlexData::try_from(&[0xD710_0000_u32, 0xF751_FE05][..]).unwrap();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0xD710_0000_u32, 0xF751_FE05][..]));
+        assert_eq!(packets.next(), None);
+    }
+
+    #[test]
+    fn packets_big() {
+        use crate::Packets;
+
+        let message = FlexData::try_from(
+            &[
+                0xD050_0106,
+                0x4769_6D6D,
+                0x6520_736F,
+                0x6D65_2073,
+                0xD0D0_0106,
+                0x6967_6E61,
+                0x6C21_0000,
+                0x0000_0000,
+            ][..],
+        )
+        .unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(
+            packets.next(),
+            Some(&[0xD050_0106, 0x4769_6D6D, 0x6520_736F, 0x6D65_2073,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xD0D0_0106, 0x6967_6E61, 0x6C21_0000, 0x0000_0000,][..])
+        );
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/flex_data/unknown_metadata_text.rs
+++ b/src/flex_data/unknown_metadata_text.rs
@@ -481,4 +481,41 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = UnknownMetadataText::try_from(
+            &[
+                0xD050_0100,
+                0x4469_6769,
+                0x7461_6C20,
+                0x4175_6469,
+                0xD090_0100,
+                0x6F20_576F,
+                0x726B_7374,
+                0x6174_696F,
+                0xD0D0_0100,
+                0x6E20_2D20,
+                0x4441_5733,
+                0x362D_3136,
+            ][..],
+        )
+        .unwrap();
+        let mut packets = message.packets();
+        assert_eq!(
+            packets.next(),
+            Some(&[0xD050_0100, 0x4469_6769, 0x7461_6C20, 0x4175_6469,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xD090_0100, 0x6F20_576F, 0x726B_7374, 0x6174_696F,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xD0D0_0100, 0x6E20_2D20, 0x4441_5733, 0x362D_3136,][..])
+        );
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,13 @@ pub mod result;
 
 mod detail;
 mod message;
+mod packets;
 mod traits;
 
 pub use ux;
 
 pub use message::*;
+pub use packets::*;
 pub use traits::*;
 
 pub mod prelude {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,7 @@
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::RebufferFrom,
     midi2_proc::TryRebufferFrom,
     Clone,
@@ -242,6 +243,46 @@ mod tests {
         let Ok(UmpMessage::Sysex7(_)) = message else {
             panic!();
         };
+    }
+
+    #[cfg(feature = "sysex7")]
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let buffer = [
+            0x3E16_0001,
+            0x0203_0405,
+            0x3E26_0607,
+            0x0809_0A0B,
+            0x3E26_0C0D,
+            0x0E0F_1011,
+            0x3E26_1213,
+            0x1415_1617,
+            0x3E26_1819,
+            0x1A1B_1C1D,
+            0x3E26_1E1F,
+            0x2021_2223,
+            0x3E26_2425,
+            0x2627_2829,
+            0x3E26_2A2B,
+            0x2C2D_2E2F,
+            0x3E32_3031,
+            0x0000_0000,
+        ];
+        let message = UmpMessage::try_from(&buffer[..]).unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(packets.next(), Some(&[0x3E16_0001, 0x0203_0405,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_0607, 0x0809_0A0B,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_0C0D, 0x0E0F_1011,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_1213, 0x1415_1617,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_1819, 0x1A1B_1C1D,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_1E1F, 0x2021_2223,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_2425, 0x2627_2829,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E26_2A2B, 0x2C2D_2E2F,][..]));
+        assert_eq!(packets.next(), Some(&[0x3E32_3031, 0x0000_0000,][..]));
+        assert_eq!(packets.next(), None);
     }
 
     #[cfg(feature = "flex-data")]

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -28,6 +28,41 @@ impl<'a> core::iter::ExactSizeIterator for PacketsIterator<'a> {
     }
 }
 
+/// Read the individual packets of a message represented with UMP packets.
+///
+/// ## Basic Usage
+///
+/// ```rust
+/// use midi2::prelude::*;
+///
+/// let mut message = flex_data::ProjectName::<Vec<u32>>::new();
+/// message.set_text("Shadows of the Forgotten Cathedral");
+///
+/// let mut packets = message.packets();
+///
+/// assert_eq!(packets.next(), Some(&[0xD0500101, 0x53686164, 0x6F777320, 0x6F662074][..]));
+/// assert_eq!(packets.next(), Some(&[0xD0900101, 0x68652046, 0x6F72676F, 0x7474656E][..]));
+/// assert_eq!(packets.next(), Some(&[0xD0D00101, 0x20436174, 0x68656472, 0x616C0000][..]));
+/// assert_eq!(packets.next(), None);
+/// ```
+///
+/// Packets may be shorter than 128 bytes for certain messages which are represented by shorter
+/// packets.
+///
+/// ```rust
+/// use midi2::prelude::*;
+///
+/// let mut message = sysex7::Sysex7::<Vec<u32>>::new();
+/// message.set_payload((0..20).map(u7::new));
+///
+/// let mut packets = message.packets();
+///
+/// assert_eq!(packets.next(), Some(&[0x30160001, 0x2030405][..]));
+/// assert_eq!(packets.next(), Some(&[0x30260607, 0x8090A0B][..]));
+/// assert_eq!(packets.next(), Some(&[0x30260C0D, 0xE0F1011][..]));
+/// assert_eq!(packets.next(), Some(&[0x30321213, 0x0][..]));
+/// assert_eq!(packets.next(), None);
+/// ```
 pub trait Packets {
     fn packets(&self) -> PacketsIterator;
 }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, Clone)]
+pub struct PacketsIterator<'a>(pub(crate) core::slice::ChunksExact<'a, u32>);
+
+impl<'a> core::iter::Iterator for PacketsIterator<'a> {
+    type Item = &'a [u32];
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.0.count()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> core::iter::FusedIterator for PacketsIterator<'a> {}
+
+impl<'a> core::iter::ExactSizeIterator for PacketsIterator<'a> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub trait Packets {
+    fn packets(&self) -> PacketsIterator;
+}

--- a/src/sysex7.rs
+++ b/src/sysex7.rs
@@ -1540,4 +1540,42 @@ mod tests {
             std::vec![]
         );
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let buffer = [
+            0x3016_0001_u32,
+            0x0203_0405,
+            0x3026_0607,
+            0x0809_0A0B,
+            0x3026_0C0D,
+            0x0E0F_1011,
+            0x3026_1213,
+            0x1415_1617,
+            0x3036_1819,
+            0x1A1B_1C1D,
+        ];
+        let message = Sysex7::try_from(&buffer[..]).unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(packets.next(), Some(&[0x3016_0001, 0x0203_0405,][..]));
+        assert_eq!(packets.next(), Some(&[0x3026_0607, 0x0809_0A0B,][..]));
+        assert_eq!(packets.next(), Some(&[0x3026_0C0D, 0x0E0F_1011,][..]));
+        assert_eq!(packets.next(), Some(&[0x3026_1213, 0x1415_1617,][..]));
+        assert_eq!(packets.next(), Some(&[0x3036_1819, 0x1A1B_1C1D,][..]));
+        assert_eq!(packets.next(), None);
+    }
+
+    #[test]
+    fn packets_empty() {
+        use crate::Packets;
+
+        let message = Sysex7::<[u32; 2]>::new();
+        let mut packets = message.packets();
+
+        assert_eq!(packets.next(), Some(&[0x3000_0000, 0x0][..]));
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/sysex8.rs
+++ b/src/sysex8.rs
@@ -1009,4 +1009,60 @@ mod tests {
         let payload = message.payload().collect::<std::vec::Vec<u8>>();
         assert_eq!(payload, std::vec![]);
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = Sysex8::try_from(
+            &[
+                0x501E_0000,
+                0x0102_0304,
+                0x0506_0708,
+                0x090A_0B0C,
+                0x502E_000D,
+                0x0E0F_1011,
+                0x1213_1415,
+                0x1617_1819,
+                0x502E_001A,
+                0x1B1C_1D1E,
+                0x1F20_2122,
+                0x2324_2526,
+                0x503C_0027,
+                0x2829_2A2B,
+                0x2C2D_2E2F,
+                0x3031_0000,
+            ][..],
+        )
+        .unwrap();
+
+        let mut packets = message.packets();
+        assert_eq!(
+            packets.next(),
+            Some(&[0x501E_0000, 0x0102_0304, 0x0506_0708, 0x090A_0B0C,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0x502E_000D, 0x0E0F_1011, 0x1213_1415, 0x1617_1819,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0x502E_001A, 0x1B1C_1D1E, 0x1F20_2122, 0x2324_2526,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0x503C_0027, 0x2829_2A2B, 0x2C2D_2E2F, 0x3031_0000,][..])
+        );
+        assert_eq!(packets.next(), None);
+    }
+
+    #[test]
+    fn packets_empty() {
+        use crate::Packets;
+
+        let message = Sysex8::<[u32; 4]>::new();
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x5001_0000, 0x0, 0x0, 0x0][..]));
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/system_common.rs
+++ b/src/system_common.rs
@@ -168,6 +168,7 @@ pub use tune_request::*;
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::Grouped,
     midi2_proc::FromBytes,
     midi2_proc::FromUmp,
@@ -301,5 +302,16 @@ mod tests {
             SystemCommon::try_from(&[0x15F1_5F00_u32][..]),
             time_code::TimeCode::try_from(&[0x15F1_5F00_u32][..]).map(|m| m.into())
         );
+    }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = SystemCommon::try_from(&[0x15F1_5F00_u32][..]).unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(packets.next(), Some(&[0x15F1_5F00_u32][..]));
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/system_common/song_position_pointer.rs
+++ b/src/system_common/song_position_pointer.rs
@@ -39,6 +39,7 @@ mod tests {
         message.set_position(u14::new(0x367D));
         assert_eq!(message, SongPositionPointer([0x1AF2_7D6C, 0x0, 0x0, 0x0]),);
     }
+
     #[test]
     fn setters_bytes() {
         let mut message = SongPositionPointer::<[u8; 3]>::new();
@@ -74,5 +75,16 @@ mod tests {
                 .position(),
             u14::new(0x367D),
         );
+    }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = SongPositionPointer::try_from(&[0x1AF2_7D6C][..]).unwrap();
+
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x1AF2_7D6C][..]));
+        assert_eq!(packets.next(), None);
     }
 }

--- a/src/ump_stream.rs
+++ b/src/ump_stream.rs
@@ -38,6 +38,7 @@ const END_FORMAT: u8 = 0x3;
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::RebufferFrom,
     midi2_proc::TryRebufferFrom,
     Clone,
@@ -449,7 +450,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn builder() {
+    fn try_from_data() {
         assert_eq!(
             UmpStream::try_from(
                 &[
@@ -495,5 +496,51 @@ mod tests {
                 .unwrap()
             ))
         );
+    }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = UmpStream::try_from(
+            &[
+                0xF403_5268,
+                0x7974_686D,
+                0x5265_7665,
+                0x6C61_7469,
+                0xF803_6F6E,
+                0x3A20_4265,
+                0x6174_7320,
+                0x4265_796F,
+                0xF803_6E64,
+                0x2042_6F75,
+                0x6E64_6172,
+                0x6965_73F0,
+                0xFC03_9F8C,
+                0x8DF0_9FA5,
+                0x81F0_9F9A,
+                0x8000_0000,
+            ][..],
+        )
+        .unwrap();
+
+        let mut packets = message.packets();
+        assert_eq!(
+            packets.next(),
+            Some(&[0xF403_5268, 0x7974_686D, 0x5265_7665, 0x6C61_7469,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xF803_6F6E, 0x3A20_4265, 0x6174_7320, 0x4265_796F,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xF803_6E64, 0x2042_6F75, 0x6E64_6172, 0x6965_73F0,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xFC03_9F8C, 0x8DF0_9FA5, 0x81F0_9F9A, 0x8000_0000,][..])
+        );
+        assert_eq!(packets.next(), None,);
     }
 }

--- a/src/ump_stream/device_identity.rs
+++ b/src/ump_stream/device_identity.rs
@@ -118,4 +118,20 @@ mod tests {
             [u7::new(0x43), u7::new(0x54), u7::new(0x32), u7::new(0x1)],
         );
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message =
+            DeviceIdentity::try_from(&[0xF002_0000, 0x000F_3328, 0x4A1E_1870, 0x4354_3201][..])
+                .unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(
+            packets.next(),
+            Some(&[0xF002_0000, 0x000F_3328, 0x4A1E_1870, 0x4354_3201][..])
+        );
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/ump_stream/endpoint_name.rs
+++ b/src/ump_stream/endpoint_name.rs
@@ -107,4 +107,33 @@ mod tests {
             std::vec![]
         );
     }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+        let message = EndpointName::try_from(
+            &[
+                0xF403_4769,
+                0x6D6D_6520,
+                0x736F_6D65,
+                0x2073_6967,
+                0xFC03_6E61,
+                0x6C20_F09F,
+                0x948A_20F0,
+                0x9F99_8C00,
+            ][..],
+        )
+        .unwrap();
+        let mut packets = message.packets();
+
+        assert_eq!(
+            packets.next(),
+            Some(&[0xF403_4769, 0x6D6D_6520, 0x736F_6D65, 0x2073_6967,][..])
+        );
+        assert_eq!(
+            packets.next(),
+            Some(&[0xFC03_6E61, 0x6C20_F09F, 0x948A_20F0, 0x9F99_8C00,][..])
+        );
+        assert_eq!(packets.next(), None);
+    }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -165,6 +165,7 @@ impl<B: crate::buffer::Ump + crate::buffer::BufferMut> crate::detail::property::
 #[derive(
     derive_more::From,
     midi2_proc::Data,
+    midi2_proc::Packets,
     midi2_proc::RebufferFrom,
     midi2_proc::TryRebufferFrom,
     Clone,
@@ -229,5 +230,16 @@ mod tests {
                 clock::Clock::try_from(&[0x0010_1234][..]).unwrap()
             ))
         );
+    }
+
+    #[test]
+    fn packets() {
+        use crate::Packets;
+
+        let message = Utility::try_from(&[0x0010_1234][..]).unwrap();
+
+        let mut packets = message.packets();
+        assert_eq!(packets.next(), Some(&[0x0010_1234][..]));
+        assert_eq!(packets.next(), None);
     }
 }


### PR DESCRIPTION
Adds a new `Packets` trait as a convenience to iterate of the packets of messages represented with Ump buffers.

#9 

## Basic Usage

```rust
use midi2::prelude::*;

let mut message = flex_data::ProjectName::<Vec<u32>>::new();
message.set_text("Shadows of the Forgotten Cathedral");

let mut packets = message.packets();

assert_eq!(packets.next(), Some(&[0xD0500101, 0x53686164, 0x6F777320, 0x6F662074][..]));
assert_eq!(packets.next(), Some(&[0xD0900101, 0x68652046, 0x6F72676F, 0x7474656E][..]));
assert_eq!(packets.next(), Some(&[0xD0D00101, 0x20436174, 0x68656472, 0x616C0000][..]));
assert_eq!(packets.next(), None);
```

Packets may be shorter than 128 bytes for certain messages which are represented by shorter
packets.

```rust
use midi2::prelude::*;

let mut message = sysex7::Sysex7::<Vec<u32>>::new();
message.set_payload((0..20).map(u7::new));

let mut packets = message.packets();

assert_eq!(packets.next(), Some(&[0x30160001, 0x2030405][..]));
assert_eq!(packets.next(), Some(&[0x30260607, 0x8090A0B][..]));
assert_eq!(packets.next(), Some(&[0x30260C0D, 0xE0F1011][..]));
assert_eq!(packets.next(), Some(&[0x30321213, 0x0][..]));
assert_eq!(packets.next(), None);
```
